### PR TITLE
fix focus roll when +2 is unchecked and +1 is checked but hidden

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -730,6 +730,9 @@ export class ExpanseActorSheet extends ActorSheet {
             <img height="75px" width="75px" src="systems/the_expanse/ui/dice/${diceData.faction}/chat/${diceData.faction}-${die3}-${diceData.stunt}.png" />`
 
             let chatFocus;
+            
+            // Calculate total focus to be applied to roll
+            const totalFocus = useFocus === 0 ? 0 : useFocus + useFocusPlus;
 
             if (useFocus === 2 && useFocusPlus === 1) {
                 chatFocus = `<b>Focus:</b> 3</br>`;
@@ -739,7 +742,7 @@ export class ExpanseActorSheet extends ActorSheet {
 
             let chatMod = `<b>Ability Rating</b>: ${abilityMod}</br>`;
 
-            resultsSum = die1 + die2 + die3 + useFocus + useFocusPlus + abilityMod + condMod;
+            resultsSum = die1 + die2 + die3 + totalFocus + abilityMod + condMod;
 
             // Stunt Points Generation
             let chatStunts = "";


### PR DESCRIPTION
Wrong total calculated when user rolls Ability by unchecking +2 after rolling checking boxes +2 and +1.

**Expected result:** roll should be 3d6 + Ability
**Observed result:** total roll was 3d6 + Ability + 1
**Reason:** +1 box is checked but hidden
**Proposed fix (implemented):** added logics to use 0 as Focus bonus when +2 box is unchecked, no matter the status of +1 check box.
**Alternative fix (not implemented):** force +1 data to be unchecked as soon as +2 box is unchecked.